### PR TITLE
str.strip() improvement

### DIFF
--- a/week2/5_String_Methods.ipynb
+++ b/week2/5_String_Methods.ipynb
@@ -470,7 +470,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "strange_string = '!@#$%!!!^&This Is Sparta!!!!!!!!!&^%$!!!#@!'\n",
+    "strange_string = '!@#$%!!!^&This! Is! Sparta!!!!!!!!!&^%$!!!#@!'\n",
     "print(strange_string.strip('~!@#$%^&*'))"
    ]
   },


### PR DESCRIPTION
demonstrate that str.strip() doesn't remove charcters from the middle of the string