### PR TITLE
fixed multiplication exercises that were effected by markdown

### DIFF
--- a/week3/Summary.ipynb
+++ b/week3/Summary.ipynb
@@ -121,18 +121,18 @@
     "</p>\n",
     "\n",
     "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = 1</code><br>\n",
-    "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = (temp_hash*ord('a')*1) % 397643</code>\n",
-    "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = (1*97*1) % 397643 = 97</samp><br>\n",
+    "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = (temp_hash * ord('a') * 1) % 397643</code>\n",
+    "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = (1 * 97 * 1) % 397643 = 97</samp><br>\n",
     "\n",
     "<p style=\"text-align: right; direction: rtl; float: right; clear: both;\">\n",
     "    שימו לב שכאן הכפלנו ב־1, כיוון שמיקום האות הוא 0 ואנו מכפילים\n",
     "    <em>באינדקס האות הבאה.</em>\n",
     "</p>\n",
     "\n",
-    "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = (temp_hash*ord('b')*2) % 397643</code>\n",
-    "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = (97*98*2) % 397643 = 19012</samp>\n",
-    "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = (temp_hash*ord('a')*3) % 397643</code>\n",
-    "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = (19012*97*3) % 397643 = 363133</samp>\n",
+    "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = (temp_hash * ord('b') * 2) % 397643</code>\n",
+    "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = (97 * 98 * 2) % 397643 = 19012</samp>\n",
+    "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">temp_hash = (temp_hash * ord('a') * 3) % 397643</code>\n",
+    "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = (19012 * 97 * 3) % 397643 = 363133</samp>\n",
     "<code style=\"text-align: left; direction: ltr; float: left; clear: both;\">return temp_hash % 100297</code>\n",
     "<samp style=\"text-align: left; direction: ltr; float: left; clear: both;\"># temp_hash = 363133 % 100297 = <b>62242</b></samp>"
    ]
@@ -853,7 +853,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fixes to readability issues of multiplication exercises, when markdown transforms `2*a*7` to "2*a*7" 