### PR TITLE
fix: change variable name to not be python's built-in function name

### DIFF
--- a/content/week06/2_Functional_Behavior.ipynb
+++ b/content/week06/2_Functional_Behavior.ipynb
@@ -325,7 +325,7 @@
    "metadata": {},
    "source": [
     "<p style=\"text-align: right; direction: rtl; float: right; clear: both;\">\n",
-    "    כתבו generator בשם <var>apply</var> שמקבל כפרמטר ראשון פונקציה (<var>func</var>), וכפרמטר שני iterable (<var dir=\"rtl\">iter</var>).<br>\n",
+    "    כתבו generator בשם <var>apply</var> שמקבל כפרמטר ראשון פונקציה (<var>func</var>), וכפרמטר שני iterable (<var dir=\"rtl\">iterable</var>).<br>\n",
     "    עבור כל איבר ב־iterable, ה־generator יניב את האיבר אחרי שהופעלה עליו הפונקציה <var>func</var>, דהיינו – <code>func(item)</code>.<br>\n",
     "</p>"
    ]


### PR DESCRIPTION
The exercise says to define a function parameter to be "iter", which is a saved keyword in Python.